### PR TITLE
Add PostgreSQL config check

### DIFF
--- a/src/lib/Godfather.ts
+++ b/src/lib/Godfather.ts
@@ -101,7 +101,7 @@ export default class Godfather extends SapphireClient {
 		};
 
 		this.fetchLanguage = async (context) => {
-			if (!context.guild) return 'en-US';
+			if (!PGSQL_ENABLED || !context.guild) return 'en-US';
 			const { guilds } = await DbSet.connect();
 			const settings = await guilds.findOne(context.guild.id, {
 				select: ['language']


### PR DESCRIPTION
While attempting to run Godfather without PostgreSQL, I ran into errors related to a PostgreSQL database not being found. It appears the source of the issue was a missing config check, which has been implemented here.