### PR TITLE
Fix role randomization issue

### DIFF
--- a/src/lib/mafia/structures/BasicSetup.ts
+++ b/src/lib/mafia/structures/BasicSetup.ts
@@ -29,10 +29,9 @@ export default class BasicSetup extends Setup {
 
 	public generate(client: Client) {
 		const generatedRoles = [];
-		const shuffled = shuffle(this.roles);
 		const uniqueRoles: Constructor<Role>[] = [];
 
-		for (const roleName of shuffled) {
+		for (const roleName of this.roles) {
 			// Role x2 becomes Role, Role
 			if (/([a-zA-Z0-9_\- ;{}]+) ?x(\d)/.test(roleName)) {
 				const matches = /([a-zA-Z0-9_\- ;{}]+) ?x(\d+)/.exec(roleName)!;
@@ -44,7 +43,7 @@ export default class BasicSetup extends Setup {
 			generatedRoles.push(BasicSetup.resolve(client, roleName, uniqueRoles));
 		}
 
-		return generatedRoles;
+		return shuffle(generatedRoles);
 	}
 
 	public ok(roles: Constructor<Role>[]) {


### PR DESCRIPTION
If I generate multiple instances of the same role by using "Role x2" (for example), they will always be adjacent in the shuffled role list.

Consider the following example:

`['Vanilla x4', 'Goon']`

Then this is either randomized to be

`['Vanilla x4', 'Goon'] -> ['Vanilla', 'Vanilla', 'Vanilla', 'Vanilla', 'Goon']`

or 

`['Goon', 'Vanilla x4'] -> ['Goon', 'Vanilla', 'Vanilla', 'Vanilla', 'Vanilla']`.

The bot then assigns these roles sequentially (i.e. player 1 in the playerlist gets the first role in the list, player 2 gets the second, etc.)

If a player had knowledge of this exploit, then town would always win under this setup (eliminate player 1, and if they're not the Goon, eliminate player 5), since players 2, 3, and 4 are always town.

This pull request resolves this.