### PR TITLE
refactor: make endgame checks more consistent

### DIFF
--- a/src/lib/mafia/factions/Coven.ts
+++ b/src/lib/mafia/factions/Coven.ts
@@ -1,7 +1,7 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const SUPPORTING_FACTIONS = ['Survivor', 'Coven'];
+const WINS_WITH = ['Survivor', 'Coven'];
 
 export default class CovenFaction extends Faction {
 	public name = 'Coven';
@@ -9,7 +9,7 @@ export default class CovenFaction extends Faction {
 	public informed = true;
 
 	public hasWon(game: Game) {
-		const aliveOpposing = game.players.filter((player) => player.isAlive && !SUPPORTING_FACTIONS.includes(player.role.faction.name)).length;
+		const aliveOpposing = game.players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role.faction.name)).length;
 		const aliveFactional = game.players.filter((player) => player.isAlive && player.role.faction.name === 'Coven').length;
 
 		return aliveOpposing === 0 && aliveFactional > 0;

--- a/src/lib/mafia/factions/Cult.ts
+++ b/src/lib/mafia/factions/Cult.ts
@@ -1,7 +1,7 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const SUPPORTING_FACTIONS = ['Witch', 'Survivor', 'Cult'];
+const WINS_WITH = ['Witch', 'Survivor', 'Cult'];
 
 export default class CultFaction extends Faction {
 	public name = 'Cult';
@@ -9,7 +9,7 @@ export default class CultFaction extends Faction {
 	public informed = true;
 
 	public hasWon(game: Game) {
-		const aliveOpposing = game.players.filter((player) => player.isAlive && !SUPPORTING_FACTIONS.includes(player.role.faction.name)).length;
+		const aliveOpposing = game.players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role.faction.name)).length;
 		const aliveFactional = game.players.filter((player) => player.isAlive && player.role.faction.name === 'Cult').length;
 		const alivePlayers = game.players.filter((player) => player.isAlive);
 

--- a/src/lib/mafia/factions/Mafia.ts
+++ b/src/lib/mafia/factions/Mafia.ts
@@ -3,10 +3,11 @@ import type Game from '@mafia/structures/Game';
 import type Player from '@mafia/structures/Player';
 import { ActionRole } from '../structures/ActionRole';
 
-const OPPOSING_FACTIONS = ['Town', 'Arsonist', 'Werewolf', 'Serial Killer', 'Juggernaut'];
+const WINS_WITH = ['Mafia', 'Survivor', 'Witch'];
+
 const filterOpposingPowerRoles = (player: Player) =>
 	(player.isAlive &&
-		OPPOSING_FACTIONS.includes(player.role!.faction.name) &&
+		!WINS_WITH.includes(player.role!.faction.name) &&
 		player.role instanceof ActionRole &&
 		player.role.canUseAction().check) ||
 	player.role.name === 'Mayor';
@@ -25,7 +26,7 @@ export default class MafiaFaction extends Faction {
 
 		const aliveMafia = players.filter((player) => player.isAlive && player.role!.faction.name === 'Mafia');
 		const aliveOpposingPrs = players.filter(filterOpposingPowerRoles);
-		const aliveOpposing = players.filter((player) => player.isAlive && OPPOSING_FACTIONS.includes(player.role!.faction.name));
+		const aliveOpposing = players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role!.faction.name));
 
 		return aliveMafia.length > 0 && aliveMafia.length >= aliveOpposing.length && aliveOpposingPrs.length === 0;
 	}

--- a/src/lib/mafia/factions/Town.ts
+++ b/src/lib/mafia/factions/Town.ts
@@ -1,7 +1,7 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const OPPOSING_FACTIONS = ['Mafia', 'Serial Killer', 'Arsonist', 'Werewolf', 'Juggernaut', 'Cult'];
+const WINS_WITH = ['Town', 'Survivor'];
 
 export default class TownFaction extends Faction {
 	public name = 'Town';
@@ -9,13 +9,10 @@ export default class TownFaction extends Faction {
 	public winCondition = 'game/factions:townWinCondition';
 
 	public hasWon(game: Game): boolean {
-		// source: https://town-of-salem.fandom.com/wiki/Victory
-		// Town Victory will occur when the Town is the last standing faction alive when all members of the Mafia,
-		// Neutral Killing are dead
 		const { players } = game;
 
 		const aliveTownies = players.filter((player) => player.isAlive && player.role!.faction.name === this.name);
-		const aliveOpposing = players.filter((player) => player.isAlive && OPPOSING_FACTIONS.includes(player.role!.faction.name));
+		const aliveOpposing = players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role!.faction.name));
 
 		return aliveTownies.length > 0 && aliveOpposing.length === 0;
 	}

--- a/src/lib/mafia/factions/neutral/Arsonist.ts
+++ b/src/lib/mafia/factions/neutral/Arsonist.ts
@@ -1,7 +1,7 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const OPPOSING_FACTIONS = ['Town', 'Serial Killer', 'Werewolf', 'Mafia', 'Juggernaut'];
+const WINS_WITH = ['Arsonist', 'Witch', 'Survivor'];
 
 export default class ArsonistFaction extends Faction {
 	public name = 'Arsonist';
@@ -11,7 +11,7 @@ export default class ArsonistFaction extends Faction {
 		const { players } = game;
 
 		const aliveArsonists = players.filter((player) => player.isAlive && player.role.faction.name === 'Arsonist');
-		const aliveOpposing = players.filter((player) => player.isAlive && OPPOSING_FACTIONS.includes(player.role!.faction.name));
+		const aliveOpposing = players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role!.faction.name));
 
 		return aliveArsonists.length > 0 && aliveOpposing.length === 0;
 	}

--- a/src/lib/mafia/factions/neutral/Juggernaut.ts
+++ b/src/lib/mafia/factions/neutral/Juggernaut.ts
@@ -1,14 +1,14 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const SUPPORTING_FACTIONS = ['Juggernaut', 'Witch', 'Survivor'];
+const WINS_WITH = ['Juggernaut', 'Witch', 'Survivor'];
 
 export default class JuggernautFaction extends Faction {
 	public name = 'Juggernaut';
 	public winCondition = 'game/factions:nkWinCondition';
 
 	public hasWon(game: Game) {
-		const aliveOpposing = game.players.filter((player) => player.isAlive && !SUPPORTING_FACTIONS.includes(player.role.faction.name)).length;
+		const aliveOpposing = game.players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role.faction.name)).length;
 		const aliveFactional = game.players.filter((player) => player.isAlive && player.role.faction.name === 'Juggernaut').length;
 
 		return aliveOpposing === 0 && aliveFactional > 0;

--- a/src/lib/mafia/factions/neutral/SerialKiller.ts
+++ b/src/lib/mafia/factions/neutral/SerialKiller.ts
@@ -1,7 +1,7 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const OPPOSING_FACTIONS = ['Town', 'Arsonist', 'Werewolf', 'Mafia', 'Juggernaut'];
+const WINS_WITH = ['Juggernaut', 'Survivor'];
 
 export default class SerialKillerFaction extends Faction {
 	public name = 'Serial Killer';
@@ -11,7 +11,7 @@ export default class SerialKillerFaction extends Faction {
 		const { players } = game;
 
 		const aliveSerialKillers = players.filter((player) => player.isAlive && player.role.faction.name === 'Serial Killer');
-		const aliveOpposing = players.filter((player) => player.isAlive && OPPOSING_FACTIONS.includes(player.role!.faction.name));
+		const aliveOpposing = players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role!.faction.name));
 
 		return aliveSerialKillers.length > 0 && aliveOpposing.length === 0;
 	}

--- a/src/lib/mafia/factions/neutral/Werewolf.ts
+++ b/src/lib/mafia/factions/neutral/Werewolf.ts
@@ -1,14 +1,14 @@
 import Faction from '@mafia/structures/Faction';
 import type Game from '@mafia/structures/Game';
 
-const SUPPORTING_FACTIONS = ['Werewolf', 'Witch', 'Survivor'];
+const WINS_WITH = ['Werewolf', 'Witch', 'Survivor'];
 
 export default class WerewolfFaction extends Faction {
 	public name = 'Werewolf';
 	public winCondition = 'game/factions:nkWinCondition';
 
 	public hasWon(game: Game) {
-		const aliveOpposing = game.players.filter((player) => player.isAlive && !SUPPORTING_FACTIONS.includes(player.role.faction.name)).length;
+		const aliveOpposing = game.players.filter((player) => player.isAlive && !WINS_WITH.includes(player.role.faction.name)).length;
 		const aliveFactional = game.players.filter((player) => player.isAlive && player.role.faction.name === 'Werewolf').length;
 
 		return aliveOpposing === 0 && aliveFactional > 0;

--- a/src/lib/mafia/structures/Game.ts
+++ b/src/lib/mafia/structures/Game.ts
@@ -517,7 +517,7 @@ export default class Game {
 		}
 
 		// reset numbered nicknames
-		if (this.settings.numberedNicknames && this.channel.guild!.me?.hasPermission('MANAGE_NICKNAMES')) {
+		if (this.settings.numberedNicknames && this.channel.guild!.me?.permissions.has('MANAGE_NICKNAMES')) {
 			for (const member of this.numberedNicknames) {
 				// only reset a nickname if it's in the correct form
 				if (member.nickname && /\[\d+\] (.+)/.test(member.nickname)) {


### PR DESCRIPTION
This way if we ever add more factions, we don't have to modify every
Faction's individual OPPOSING_FACTIONS