### PR TITLE
change CI to only work on pushes to master (and 1.5.0 for now) and PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches-ignore:
-      - 'legacy-python'
+    branches:
+      - master
+      - 1.5.0
     paths:
       - '**.ts'
       - 'yarn.lock'


### PR DESCRIPTION
this is to prevent PRs from branches inside the repo having both the PR and push CI